### PR TITLE
README: Use Linux 6.17 in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ git clone https://github.com/robn/quiz.git
 Build a kernel:
 
 ```
-$ ./quiz-kernel -k 6.1
+$ ./quiz-kernel -k 6.17
 ```
 
 Build the root image:


### PR DESCRIPTION
quiz-kernel -k 6.1 does not "just" work anymore,
so reference a working version instead.